### PR TITLE
Add title and author to PDF metadata

### DIFF
--- a/settings.tex
+++ b/settings.tex
@@ -25,6 +25,12 @@
 \usepackage[final]{microtype}
 \usepackage{caption}
 \usepackage[hidelinks]{hyperref} % hidelinks removes colored boxes around references and links
+\AtBeginDocument{%
+	\hypersetup{
+		pdftitle=\getTitle,
+		pdfauthor=\getAuthor,
+	}
+}
 \usepackage{ifthen}
 
 % Themes


### PR DESCRIPTION
Add title and author to PDF metadata. This allows PDF viewers to display the correct title in the window title bar (instead of the filename).