### PR TITLE
Capitalize references

### DIFF
--- a/settings.tex
+++ b/settings.tex
@@ -34,6 +34,18 @@
 }
 \usepackage{ifthen}
 
+\addto\extrasamerican{
+	\def\lstnumberautorefname{line}
+	\def\chapterautorefname{Chapter}
+	\def\sectionautorefname{Section}
+	\def\subsectionautorefname{Subsection}
+	\def\subsubsectionautorefname{Subsubsection}
+}
+
+\addto\extrasngerman{
+	\def\lstnumberautorefname{Zeile}
+}
+
 % Themes
 \ifthenelse{\equal{\detokenize{dark}}{\jobname}}{%
   % Dark theme

--- a/settings.tex
+++ b/settings.tex
@@ -35,7 +35,7 @@
 \usepackage{ifthen}
 
 \addto\extrasamerican{
-	\def\lstnumberautorefname{line}
+	\def\lstnumberautorefname{Line}
 	\def\chapterautorefname{Chapter}
 	\def\sectionautorefname{Section}
 	\def\subsectionautorefname{Subsection}


### PR DESCRIPTION
Capitalize references and correctly reference lines in listings.