### PR TITLE
Department of XYZ -> School of XYZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # LaTeX template for TUM theses
 
+**⚠️⚠️ On the 01. October 2022 all faculties will be dissolved in favor of the new Schools which will be founded on 01. October 2022. This means, in case you hand in your thesis after the 01. October 2022, you have to replace `Department of XYZ` with `School of XYZ`. This change is already reflected in the latest version of this template. ⚠️⚠️**
+
 This is a LaTeX template created according to the guidelines for TUM informatics theses in SS 2013. **Always check the [current formatting guidelines][thesis-guidelines] before you hand in.** See [`build/main.pdf`][sample-pdf] for an example PDF created with this template.
 
 Note: Because of copyright considerations, TUM logos are not included in this template. Unfortunately, the logos are also not available on the MyTUM website anymore.
+Your supervisor should be able to hand them to you.
 
-Comments & contributions welcome!
+Comments & contributions are welcome!
 
 ## Quickstart
 

--- a/main.tex
+++ b/main.tex
@@ -12,6 +12,7 @@
 % TODO: change thesis information
 \newcommand*{\getUniversity}{Technische Universität München}
 \newcommand*{\getFaculty}{Informatics}
+\newcommand*{\getSchool}{Computation, Information and Technology}
 \newcommand*{\getTitle}{Thesis title}
 \newcommand*{\getTitleGer}{Titel der Abschlussarbeit}
 \newcommand*{\getAuthor}{Author}

--- a/pages/cover.tex
+++ b/pages/cover.tex
@@ -16,7 +16,7 @@
   }
 
   \vspace{5mm}
-  {\huge\MakeUppercase{Department of \getFaculty{}}}\\
+  {\huge\MakeUppercase{School of \getSchool{}}}\\
 
   \vspace{5mm}
   {\large\MakeUppercase{\getUniversity{}}}\\

--- a/pages/title.tex
+++ b/pages/title.tex
@@ -8,7 +8,7 @@
   }
 
   \vspace{5mm}
-  {\huge\MakeUppercase{Department of \getFaculty{}}}\\
+  {\huge\MakeUppercase{School of \getSchool{}}}\\
 
   \vspace{5mm}
   {\large\MakeUppercase{\getUniversity{}}}\\
@@ -24,9 +24,9 @@
 
   \vspace{15mm}
   \begin{tabular}{l l}
-    Author:          & \getAuthor{} \\
-    Supervisor:      & \getSupervisor{} \\
-    Advisor:         & \getAdvisor{} \\
+    Author:          & \getAuthor{}         \\
+    Supervisor:      & \getSupervisor{}     \\
+    Advisor:         & \getAdvisor{}        \\
     Submission Date: & \getSubmissionDate{} \\
   \end{tabular}
 


### PR DESCRIPTION
Updates the template for the new School system. Replaces all mentions of `Department of XYZ` with `School of XYZ`.
The official [Thesis Guidelines and Topics - Formatting Guidelines](https://www.in.tum.de/en/in/current-students/administrative-matters/thesis-guidelines-and-topics/) have not been updated yet, but based on the information provided by the [Academic Advising Team](https://www.in.tum.de/en/in/current-students/advising-and-support/academic-advising/), this will be the most likely change.