### PR TITLE
Generate fachschaft_print.pdf to remove second page on two-page

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -17,5 +17,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: thesis
-        path: build/main.pdf
+        path: |
+          - build/main.pdf
+          - build/fachschaft_print.pdf
         retention-days: 14

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,8 +10,9 @@ stages:
 pdf:
   stage: build
   script:
-  - make pdf 
+    - make pdf
   artifacts:
     paths:
-    - build/main.pdf
+      - build/main.pdf
+      - build/fachschaft_print.pdf
     expire_in: 1 week

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -7,3 +7,5 @@ sub makeglossaries {
   popd;
   return $return;
 }
+
+$success_cmd = 'make _fachschaft-print'

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,29 @@ OUT  := build
 
 .PHONY: pdf
 pdf:
-	latexmk -interaction=nonstopmode -outdir="$(OUT)" -pdf -halt-on-error -jobname="$(jobname)" $(FILE)
+	+latexmk -interaction=nonstopmode -outdir="$(OUT)" -pdf -halt-on-error -jobname="$(jobname)" $(FILE)
 
 .PHONY: watch
 watch:
-	latexmk -interaction=nonstopmode -outdir="$(OUT)" -pdf -pvc -halt-on-error -jobname="$(jobname)" $(FILE)
+	+latexmk -interaction=nonstopmode -outdir="$(OUT)" -pdf -pvc -halt-on-error -jobname="$(jobname)" $(FILE)
+
+.PHONY: _fachschaft-print
+_fachschaft-print:
+	@if grep -sq '^TUM-Dev LaTeX-Thesis-Template: twoside$$' build/main.log; then \
+		if [ "$(OUT)/fachschaft_print.pdf" -nt "$(OUT)/$(FILE).pdf" ]; then \
+			echo "fachschaft_print.pdf is up to date"; \
+		else \
+			echo "Building fachschaft_print.pdf..."; \
+			if ! command -v pdfjam >/dev/null; then \
+				echo "PDFJAM not installed. Can not build fachschaft_print.pdf."; \
+				rm -f "$(OUT)/_fachschaft_print.pdf"; \
+			else \
+				pdfjam --twoside --a4paper -o "$(OUT)/fachschaft_print.pdf" "$(OUT)/$(FILE).pdf" 1,3-; \
+			fi \
+		fi \
+	else \
+		cp "$(OUT)/$(FILE).pdf" "$(OUT)/fachschaft_print.pdf"; \
+	fi;
 
 .PHONY: clean
 clean:

--- a/settings.tex
+++ b/settings.tex
@@ -34,6 +34,15 @@
 }
 \usepackage{ifthen}
 
+% for fachschaft_print.pdf
+\makeatletter
+\if@twoside
+	\typeout{TUM-Dev LaTeX-Thesis-Template: twoside}
+\else
+	\typeout{TUM-Dev LaTeX-Thesis-Template: oneside}
+\fi
+\makeatother
+
 \addto\extrasamerican{
 	\def\lstnumberautorefname{Line}
 	\def\chapterautorefname{Chapter}


### PR DESCRIPTION
According to the [MPIC Fachschaft's website](https://mpic.fs.tum.de/en/services/abschlussarbeiten/), there should be no empty page after the cover page:
> The file must contain a cover (**without** a blank page behind it)

I amended the Makefile to generate a `fachschaft_print.pdf` as well, which has the second, empty page stripped for two-page theses.

Let me know if you feel like `fachschaft_print.pdf` should instead be called `mpic_fachschaft_print.pdf` or something along the line.