### PR TITLE
disclaimer.tex: account for longer names

### DIFF
--- a/pages/disclaimer.tex
+++ b/pages/disclaimer.tex
@@ -5,6 +5,6 @@ I confirm that this \MakeLowercase{\getDoctype{}} is my own work and I have docu
 
 \vspace{15mm}
 \noindent
-\getSubmissionLocation{}, \getSubmissionDate{} \hspace{50mm} \getAuthor{}
+\getSubmissionLocation{}, \getSubmissionDate{} \hspace{\fill} \getAuthor{}
 
 \cleardoublepage{}


### PR DESCRIPTION
Hi!

I noticed that my name gets wrapped in `disclaimer.tex.`

<img width="1305" alt="Screenshot 2023-11-07 at 11 40 26" src="https://github.com/TUM-Dev/tum-thesis-latex/assets/24569379/3758c76f-911c-4f77-aec1-0ae1caeb7590">

Address this by making the `hspace` dynamic.

This still bears the risk of line-wrapping for even longer names, so it might be worth considering moving the name to a new line altogether.