### PR TITLE
Fix missing character warning

### DIFF
--- a/chapters/01_introduction.tex
+++ b/chapters/01_introduction.tex
@@ -76,9 +76,9 @@ See~\autoref{tab:sample}, \autoref{fig:sample-drawing}, \autoref{fig:sample-plot
         xlabel=X
       ]
       \addplot table[x=a, y=b]{\exampleA};
-      \addlegendentry{Example A};
+      \addlegendentry{Example A}
       \addplot table[x=a, y=b]{\exampleB};
-      \addlegendentry{Example B};
+      \addlegendentry{Example B}
     \end{axis}
   \end{tikzpicture}
   \caption[Example plot]{An example for a simple plot.}\label{fig:sample-plot}


### PR DESCRIPTION
Fixes the warning about 

```
main.tex|| Missing character: There is no ; in font nullfont!
```

It is very minor, but the first thing after cloning / using the repo is often to make it compile, and removing this little warning helps the user to not stumble over it