### PR TITLE
Change supervisor and advisor labels according to formatting instructions

### DIFF
--- a/pages/title.tex
+++ b/pages/title.tex
@@ -25,8 +25,8 @@
   \vspace{15mm}
   \begin{tabular}{l l}
     Author:          & \getAuthor{}         \\
-    Supervisor:      & \getSupervisor{}     \\
-    Advisor:         & \getAdvisor{}        \\
+    Examiner:      & \getSupervisor{}     \\
+    Supervisor:         & \getAdvisor{}        \\
     Submission Date: & \getSubmissionDate{} \\
   \end{tabular}
 


### PR DESCRIPTION
As strange as it may seem, [formatting instructions](https://www.cit.tum.de/en/cit/studies/students/thesis-completing-your-studies/informatics/) now require supervisor to be called "Examiner" and advisor "Supervisor"...

> First page:
    Repeat the cover information. 
    Also include:
        The title must be written in English as well as German.
        Examiner: The first and last names of the supervisor including the academic title
        Supervisor/s: The first and last names of the advisor/s including the academic title
        Submission date: (must not be handwritten)
            the actual submission date
            or the submission deadline (15th of the month)
    Please note: 
    Do not include your student registration number or other personal data such as date of birth.
    Do not attach any notes, images and company name or logo.

This change apparently happened between [October 3, 2023](http://web.archive.org/web/20231003015203/https://www.cit.tum.de/en/cit/studies/students/thesis-completing-your-studies/informatics/) and  [March 14, 2024](http://web.archive.org/web/20240314150827/https://www.cit.tum.de/en/cit/studies/students/thesis-completing-your-studies/informatics/)