### PR TITLE
Use PDF/A

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -6,9 +6,6 @@
 %\documentclass[headsepline,footsepline,footinclude=false,fontsize=11pt,paper=a4,listof=totoc,bibliography=totoc,BCOR=12mm,DIV=12]{scrbook} % two-sided
 \documentclass[headsepline,footsepline,footinclude=false,oneside,fontsize=11pt,paper=a4,listof=totoc,bibliography=totoc]{scrbook} % one-sided
 
-% TODO: change citation style in settings
-\input{settings}
-
 % TODO: change thesis information
 \newcommand*{\getUniversity}{Technische Universität München}
 \newcommand*{\getFaculty}{Informatics}
@@ -20,8 +17,12 @@
 \newcommand*{\getDoctype}{Bachelor's Thesis, Master's Thesis, \ldots}
 \newcommand*{\getSupervisor}{Supervisor}
 \newcommand*{\getAdvisor}{Advisor}
+\newcommand*{\getKeywords}{keyword;another keyword;one more}
 \newcommand*{\getSubmissionDate}{Submission date}
 \newcommand*{\getSubmissionLocation}{Munich}
+
+% TODO: change citation style in settings
+\input{settings}
 
 \begin{document}
 

--- a/main.xmpdata
+++ b/main.xmpdata
@@ -1,0 +1,6 @@
+% Metadata for PDF
+\Author{\getAuthor}
+\Title{\getTitle}
+\Keywords{\getKeywords}
+\Subject{\getDoctype}
+

--- a/settings.tex
+++ b/settings.tex
@@ -1,5 +1,6 @@
 \PassOptionsToPackage{table,svgnames,dvipsnames}{xcolor}
 
+\usepackage[a-2u]{pdfx} % generate PDF/A: archival compliant, self-contained pdf
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \usepackage[sc]{mathpazo}
@@ -25,14 +26,10 @@
 \usepackage[final]{microtype}
 \usepackage{caption}
 \usepackage[printonlyused]{acronym}
-\usepackage[hidelinks]{hyperref} % hidelinks removes colored boxes around references and links
-\AtBeginDocument{%
-	\hypersetup{
-		pdftitle=\getTitle,
-		pdfauthor=\getAuthor,
-	}
-}
 \usepackage{ifthen}
+
+
+\hypersetup{hidelinks} % removes colored boxes around references and links
 
 % for fachschaft_print.pdf
 \makeatletter


### PR DESCRIPTION
PDF/A is self-contained, embeds all used fonts and references, and ensures that the document will remain accessible and displayed correctly over time. This format is more suitable for long-term storing of documents like academic works. Some universities and institutions even accept papers and works in PDF/A format only.