### PR TITLE
Add template for software used table

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -35,6 +35,8 @@
 
 \input{pages/title}
 \input{pages/disclaimer}
+% Uncomment the following line if you want to include a software usage table (see example in pages/software_used.tex)
+% \input{pages/software_used}
 \input{pages/acknowledgments}
 \input{pages/abstract}
 \microtypesetup{protrusion=false}

--- a/pages/software_used.tex
+++ b/pages/software_used.tex
@@ -1,0 +1,70 @@
+\addcontentsline{toc}{chapter}{Software used}
+
+\thispagestyle{empty}
+
+\begin{center}
+    {\usekomafont{sectioning}\usekomafont{section} Software used}
+\end{center}
+I used the following software when writing my thesis:
+\begin{table}[h]
+\centering
+\small
+\renewcommand{\arraystretch}{1.2}
+
+\begin{tabular}{|p{3.5cm}|p{11.5cm}|}
+\hline
+\rowcolor{TUMSecondaryBlue}
+\textcolor{TUMWhite}{\textbf{Used software}} &
+\textcolor{TUMWhite}{\textbf{Details}} \\
+\hline
+
+{\raggedright Microsoft Copilot (ChatGPT 4)\par}
+&
+\begin{tabular}{@{}p{2.2cm}p{8.9cm}@{}}
+
+\textbf{Date:} & 03.11.2024 \\
+\textbf{Use case:} & Creation of research question \\
+\textbf{Scope:} & Chapter 1, p.~2 \\
+\textbf{Comments:} & Chat history in Appendix 2 \\
+\cline{1-2}
+
+\textbf{Date:} & 02.01.2025 \\
+\textbf{Use case:} & Creation of program code to visualize the research data.\\
+\textbf{Scope:} & Chapter 5, pp.~35--37 \\
+\textbf{Comments:} & with Python \\
+\cline{1-2}
+
+\textbf{Date:} & 16.01.2025 \\
+\textbf{Use case:} & Linguistic quality improvement \\
+\textbf{Scope:} & Entire work \\
+\textbf{Comments:} & -- \\
+
+\end{tabular}
+\\
+\hline
+
+{\raggedright Mistral Le Chat\par}
+&
+\begin{tabular}{@{}p{2.2cm}p{8.9cm}@{}}
+
+\textbf{Date:} & 10.02.2025 \\
+\textbf{Use case:} & mediaTUM: https://mediatum.ub.tum.de/1290447 \\
+\textbf{Scope:} & Selected sections (e.g., Chapter 2) \\
+\textbf{Comments:} & mediaTUM Gesamtbestand -> Einrichtungen -> Serviceeinrichtungen -> Universitätsbibliothek -> E-Learning -> Zitieren \\
+\cline{1-2}
+
+\textbf{Date:} & 18.02.2025 \\
+\textbf{Use case:} & Brainstorming and structuring ideas \\
+\textbf{Scope:} & Early draft phases \\
+\textbf{Comments:} & No direct content copied \\
+
+\end{tabular}
+\\
+\hline
+
+\end{tabular}
+
+\caption{Software used during the thesis}
+\end{table}
+
+\cleardoublepage{}


### PR DESCRIPTION
This PR adds a software usage table following the recommendations from the mediaTUM citation guide.

1) The table was formatted to align with the overall thesis layout.
2) It is commented out by default and therefore not included unless explicitly enabled.
3) According to mediaTUM citing template. https://mediatum.ub.tum.de/1290447
<img width="528" height="365" alt="Screenshot 2026-04-16 181228" src="https://github.com/user-attachments/assets/4fd28647-b403-4478-9c48-29f52e15534b" />
<img width="561" height="507" alt="Screenshot 2026-04-16 181220" src="https://github.com/user-attachments/assets/2f4649e4-b00f-458e-b858-ada1d1932877" />

